### PR TITLE
introduce tolerance on floating point numbers by using Test::Number::Del...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ my %mm = (
     VERSION_FROM      => 'lib/JavaScript/V8.pm', # finds $VERSION
     PREREQ_PM         => {
       'ExtUtils::XSpp' => '0.11',
+      'Test::Number::Delta' => 0,
     }, # e.g., Module::Name => 1.1
     ABSTRACT_FROM  => 'lib/JavaScript/V8.pm', # retrieve abstract from module
     AUTHOR         => 'Pawel Murias <pawelmurias@gmail.org>',

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 use Test::More;
+use Test::Number::Delta within => 1e-9;
 use JavaScript::V8;
 use strict;
 use warnings;
@@ -16,7 +17,7 @@ is $val,777,"integers";
 
 is($context->eval("'\x{a3}'"), "\x{a3}", 'latin-1 strings');
 
-is($context->eval("1.34"), 1.34, 'numbers');
+delta_ok($context->eval("1.34"), 1.34, 'numbers');
 ok(!defined $context->eval('undefined'), 'undefined');
 ok(!defined $context->eval('null'), 'null');
 

--- a/t/types.t
+++ b/t/types.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use Test::More;
+use Test::Number::Delta within => 1e-9;
 use JavaScript::V8;
 
 use utf8;
@@ -14,7 +15,7 @@ is $context->eval('(function(v) { return v })')->(2174652970), 2174652970, '32-b
 is $context->eval('(function(v) { return v })')->(-2174652970), -2174652970, '32-bit numbers  are ok';
 is $context->eval('(function(v) { return v })')->(-2170), -2170, '32-bit numbers  are ok';
 is $context->eval('(function(v) { return v })')->(2170), 2170, '32-bit numbers  are ok';
-is $context->eval('(function(v) { return v })')->(2.34234), 2.34234, 'real numbers are ok';
+delta_ok $context->eval('(function(v) { return v })')->(2.34234), 2.34234, 'real numbers are ok';
 
 is $context->eval('(function(v) { return v + 2; })')->(2), 4;
 is $context->eval('(function(v) { return v + 2; })')->('2'), '22', 'string converts into a string';


### PR DESCRIPTION
...ta::delta_ok instead of string equality

You remember my RT ticket https://rt.cpan.org/Ticket/Display.html?id=73963 ?

I've fixed the two broken tests by replacing Test::More::is() with Test::Number::Delta::delta_ok() and adding Test::Number::Delta to the prerequisites.

Hope you like it,

Best wishes,
