### PR TITLE
Updates for compatibility and bug fixing

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,15 +42,4 @@ if(ExtUtils::MakeMaker->can("VERSION") && ExtUtils::MakeMaker->VERSION(6.46)) {
   };
 }
 
-if(gcc_version($CC) >= 4.5) {
-  $mm{CCFLAGS} = '-fpermissive';
-}
-
 WriteMakefile(%mm);
-
-sub gcc_version {
-  my($cc) = @_;
-  my $gcc_out = qx{$cc -v 2>&1};
-  # Just the first two digits
-  $gcc_out =~ /gcc version (\d+\.\d+)/ ? $1 : 0;
-}

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -841,7 +841,7 @@ XS(v8method) {
 SV*
 V8Context::function2sv(Handle<Function> fn) {
     CV          *code = newXS(NULL, v8closure, __FILE__);
-    (void) new V8FunctionData(this, fn->ToObject(), (SV*)code);
+    V8ObjectData *data = new V8FunctionData(this, fn->ToObject(), (SV*)code);
     return newRV_noinc((SV*)code);
 }
 
@@ -876,7 +876,7 @@ V8Context::object2blessed(Handle<Object> obj) {
             Local<Function> fn = Local<Function>::Cast(property);
 
             CV *code = newXS(NULL, v8method, __FILE__);
-            (void) new V8FunctionData(this, fn, (SV*)code);
+            V8ObjectData *data = new V8FunctionData(this, fn, (SV*)code);
 
             GV* gv = (GV*)*hv_fetch(stash, *String::AsciiValue(name), name->Length(), TRUE);
             gv_init(gv, stash, *String::AsciiValue(name), name->Length(), GV_ADDMULTI); /* vivify */

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -680,15 +680,17 @@ V8Context::av2array(AV *av, HandleMap& seen, long ptr) {
 
 Handle<Object>
 V8Context::hv2object(HV *hv, HandleMap& seen, long ptr) {
-    I32 len;
-    char *key;
-    SV *val;
+    HE *he;
+    SV *key;
+    SV *value;
 
     hv_iterinit(hv);
     Handle<Object> object = Object::New();
     seen[ptr] = object;
-    while (val = hv_iternextsv(hv, &key, &len)) {
-        object->Set(String::New(key, len), sv2v8(val, seen));
+    while (he = hv_iternext(hv)) {
+	key = HeSVKEY_force(he);
+	value = HeVAL(he);
+        object->Set(sv2v8str(key), sv2v8(val, seen));
     }
     return object;
 }

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -473,6 +473,10 @@ V8Context::sv2v8(SV *sv, HandleMap& seen) {
         char *utf8 = SvPVutf8_nolen(sv);
         return String::New(utf8, SvCUR(sv));
     }
+    if (SvUOK(sv)) {
+	UV v = SvUV(sv);
+	return v <= 0xffffffffUL ? (Handle<Number>)Integer::NewFromUnsigned(v) : Number::New(SvNV(sv));
+    }
     if (SvIOK(sv)) {
         IV v = SvIV(sv);
         return (v <= INT32_MAX && v >= INT32_MIN) ? (Handle<Number>)Integer::New(v) : Number::New(SvNV(sv));

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -223,6 +223,7 @@ public:
 class PerlFunctionData : public PerlObjectData {
 private:
     SV *rv;
+    Local<Value> *thisWrapped;
 
 protected:
     virtual Handle<Value> invoke(const Arguments& args);
@@ -236,13 +237,17 @@ public:
                   context_->make_function->Call(
                       context_->context->Global(),
                       1,
-                      &External::Wrap(this)
+                      thisWrapped = new Local<Value>(External::Wrap(this))
                   )
               ),
               cv
           )
        , rv(cv ? newRV_noinc(cv) : NULL)
     { }
+
+    ~PerlFunctionData() {
+        delete thisWrapped;
+    }
 
     static Handle<Value> v8invoke(const Arguments& args) {
         PerlFunctionData* data = static_cast<PerlFunctionData*>(External::Unwrap(args[0]));

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -262,7 +262,7 @@ void PerlObjectData::add_size(size_t bytes_) {
 Handle<Value>
 PerlFunctionData::invoke(const Arguments& args) {
     SETUP_PERL_CALL();
-    int count = call_sv(rv, G_SCALAR | G_EVAL);
+    (void) call_sv(rv, G_SCALAR | G_EVAL);
     CONVERT_PERL_RESULT();
 }
 
@@ -282,7 +282,7 @@ public:
 Handle<Value>
 PerlMethodData::invoke(const Arguments& args) {
     SETUP_PERL_CALL(mXPUSHs(context->v82sv(args.This())))
-    int count = call_method(name.c_str(), G_SCALAR | G_EVAL);
+    (void) call_method(name.c_str(), G_SCALAR | G_EVAL);
     CONVERT_PERL_RESULT()
 }
 
@@ -520,7 +520,7 @@ V8Context::v82sv(Handle<Value> value, SvMap& seen) {
         return newSV(0);
 
     if (value->IsNull())
-        return newSv(0);
+        return newSV(0);
 
     if (value->IsInt32())
         return newSViv(value->Int32Value());
@@ -576,7 +576,7 @@ V8Context::v82sv(Handle<Value> value) {
 void
 V8Context::fill_prototype(Handle<Object> prototype, HV* stash) {
     HE *he;
-    while (he = hv_iternext(stash)) {
+    while ((he = hv_iternext(stash))) {
         SV *key = HeSVKEY_force(he);
         Local<String> name = String::New(SvPV_nolen(key));
 
@@ -680,17 +680,27 @@ V8Context::av2array(AV *av, HandleMap& seen, long ptr) {
 
 Handle<Object>
 V8Context::hv2object(HV *hv, HandleMap& seen, long ptr) {
-    HE *he;
-    SV *key;
-    SV *value;
+    HE* he;
+    SV* key;
+    SV* value;
+    STRLEN keylen;
+    const char* keyval;
 
     hv_iterinit(hv);
     Handle<Object> object = Object::New();
     seen[ptr] = object;
-    while (he = hv_iternext(hv)) {
-	key = HeSVKEY_force(he);
+    while ((he = hv_iternext(hv))) {
 	value = HeVAL(he);
-        object->Set(sv2v8str(key), sv2v8(val, seen));
+        if (HeUTF8(he)) {
+            /* Apparently HeSVKEY returns the hash key scalar without the
+             * UTF-8 flag enabled. Asking the UTF-8 bytes in sv2v8str causes
+             * double-encoded UTF-8 to be seen by v8. */
+            keyval = HePV(he, keylen);
+            object->Set(String::New(keyval, keylen), sv2v8(value, seen));
+        } else {
+            key = HeSVKEY_force(he);
+            object->Set(sv2v8str(key), sv2v8(value, seen));
+        }
     }
     return object;
 }
@@ -708,8 +718,8 @@ V8Context::array2sv(Handle<Array> array, SvMap& seen) {
 
     seen.add(array, PTR2IV(av));
 
-    for (int i = 0; i < array->Length(); i++) {
-        Handle<Value> elementVal = array->Get( Integer::New( i ) );
+    for (uint32_t i = 0; i < array->Length(); i++) {
+        Handle<Value> elementVal = array->Get( Integer::NewFromUnsigned( i ) );
         av_push(av, v82sv(elementVal, seen));
     }
     return rv;
@@ -728,8 +738,8 @@ V8Context::object2sv(Handle<Object> obj, SvMap& seen) {
     seen.add(obj, PTR2IV(hv));
 
     Local<Array> properties = obj->GetPropertyNames();
-    for (int i = 0; i < properties->Length(); i++) {
-        Local<Integer> propertyIndex = Integer::New( i );
+    for (uint32_t i = 0; i < properties->Length(); i++) {
+        Local<Integer> propertyIndex = Integer::NewFromUnsigned( i );
         Local<String> propertyName = Local<String>::Cast( properties->Get( propertyIndex ) );
         String::Utf8Value propertyNameUTF8( propertyName );
 
@@ -831,7 +841,7 @@ XS(v8method) {
 SV*
 V8Context::function2sv(Handle<Function> fn) {
     CV          *code = newXS(NULL, v8closure, __FILE__);
-    V8ObjectData *data = new V8FunctionData(this, fn->ToObject(), (SV*)code);
+    (void) new V8FunctionData(this, fn->ToObject(), (SV*)code);
     return newRV_noinc((SV*)code);
 }
 
@@ -856,7 +866,7 @@ V8Context::object2blessed(Handle<Object> obj) {
         stash = gv_stashpv(package, GV_ADD);
 
         Local<Array> properties = prototype->GetPropertyNames();
-        for (int i = 0; i < properties->Length(); i++) {
+        for (uint32_t i = 0; i < properties->Length(); i++) {
             Local<String> name = properties->Get(i)->ToString();
             Local<Value> property = prototype->Get(name);
 
@@ -866,7 +876,7 @@ V8Context::object2blessed(Handle<Object> obj) {
             Local<Function> fn = Local<Function>::Cast(property);
 
             CV *code = newXS(NULL, v8method, __FILE__);
-            V8ObjectData *data = new V8FunctionData(this, fn, (SV*)code);
+            (void) new V8FunctionData(this, fn, (SV*)code);
 
             GV* gv = (GV*)*hv_fetch(stash, *String::AsciiValue(name), name->Length(), TRUE);
             gv_init(gv, stash, *String::AsciiValue(name), name->Length(), GV_ADDMULTI); /* vivify */

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -354,6 +354,8 @@ V8Context::~V8Context() {
       it->second.Dispose();
     }
     context.Dispose();
+    string_wrap.Dispose();
+    make_function.Dispose();
     while(!V8::IdleNotification()); // force garbage collection
 }
 

--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -515,10 +515,10 @@ SV* V8Context::seen_v8(Handle<Object> object) {
 SV *
 V8Context::v82sv(Handle<Value> value, SvMap& seen) {
     if (value->IsUndefined())
-        return &PL_sv_undef;
+        return newSV(0);
 
     if (value->IsNull())
-        return &PL_sv_undef;
+        return newSv(0);
 
     if (value->IsInt32())
         return newSViv(value->Int32Value());


### PR DESCRIPTION
Hey,

there are a number of things that are broken in the libv8 integration. I've got a bunch of fixes with some titles. I know this commit history isn't the cleanest ever so feel free to just squash all the changes into one.
- FIrstly, the SvUOK change allows use of 32-bit unsigned values on 32-bit builds. Without this fix, large enough value gets turned into a negative 32-bit integer value when going from Perl to V8. There is no issue in 64-bit build however.
- Moving on, newSV(0) is required rather than &PL_sv_undef so that JS-returned arrays and hashes have elements that can be assigned to normally.
- Then I noticed by creating and disposing many contexts that string_wrap and make_function were leaked per created context. So, I added disposing of those to reduce memory leakage. (I've seen that Javascript::V8 also leaks the Perl functions bound to the context, but my perl-fu is not sufficient to understand why that occurs, so I haven't fixed that issue.)
- Then there is an issue with the hash key iteration because the UTF-8 flag is ignored. There may be bugs in Perl here. For instance, HeSVKEY_force() returns a SV, and SVs are supposed to have UTF-8 flag on if their char\* content is in fact UTF-8. However, I think in this case for some reason this doesn't happen. So, there's some complexity in the hv2object loop to test if key is UTF-8. The old code actually replaces e.g. latin1 characters in non-utf8 strings with "\ufffe" because it passes the data in binary fashion to String::new(). hv_iternextsv() is broken in Unicode world.
- I also silenced a bunch of warnings by casting to (void) rather than using a local variable with no further usages. The (void) is documentation for "I'm ignoring the return value intentionally".
- I used uint32_t to avoid a comparison between signed and unsigned message.
