### PR TITLE
Enable installation on systems with Clang++ as the default/only C++ compiler

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,10 +13,21 @@ check_lib_or_exit(
         : (),
 );
 
-my $CC = 'c++';
+my $CC;
 
-if ($#ARGV + 1) {
-    $CC = $ARGV[0];
+if (system('c++ --version') == 0) {
+    $CC = 'c++';
+}
+elsif (system('g++ --version') == 0) {
+    $CC = 'g++';
+}
+elsif (system('clang++ --version') == 0) {
+    $CC = 'clang++';
+}
+else {
+    #set to g++ and hope for the best
+    $CC = 'g++';
+    warn 'No supported compiler found, defaulting to g++';
 }
 
 my %mm = (

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ check_lib_or_exit(
         : (),
 );
 
-my $CC = 'g++';
+my $CC = 'c++';
 
 if ($#ARGV + 1) {
     $CC = $ARGV[0];

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,11 @@ check_lib_or_exit(
 );
 
 my $CC = 'g++';
+
+if ($#ARGV + 1) {
+    $CC = $ARGV[0];
+}
+
 my %mm = (
     NAME              => 'JavaScript::V8',
     VERSION_FROM      => 'lib/JavaScript/V8.pm', # finds $VERSION

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@ javascript-v8
 
 Perl interface to V8 JavaScript engine
 
-**To Install:**
+**To Install (CPAN installation)**
+
+    cpan JavaScript::V8
+
+
+**To Install (non-CPAN install):**
 
 Install V8 if not already installed:
 
@@ -11,8 +16,10 @@ Install V8 if not already installed:
 
 Create Makefile
 
-    perl Makefile.PL [compiler]
+    perl Makefile.PL
 
-  (this defaults to g++, but you can also specify clang++)  
+Install
+    
+    make install
 
-Full Details at https://metacpan.org/pod/JavaScript::V8
+More information at https://metacpan.org/pod/JavaScript::V8


### PR DESCRIPTION
Some systems (including FreeBSD systems as of 2012) use Clang rather than G++ as their default compiler. This would result in problems installing this module. See [this RT issue](https://rt.cpan.org/Public/Bug/Display.html?id=91874) for an example

**This change does the following:**
- Changes Makefile.PL to enable it to try to detect the compiler(s) present on the system and in the path
  - Default order is c++ (this is usually a copy of the preferred compiler), then g++, then clang++. If none is present, it sets the compiler to g++, warns, and hopes for the best (which, other than the warning, is the current/old behavior)
- Fixes compiler warnings/errors that are given by Clang if used instead of g++
- Adds a Readme.MD to the repo, as this makes Github repositories a bit more user-friendly IMO (I can remove this if desired)

**The following tests were done:**
- Check install process with only (clang++, c++, g++) present
- Run all tests under 't' folder with binaries built using each built binary

I've been able to test this on my personal dev server (x64 Ubuntu 14.04.1), as well as a VM running FreeBSD 10.1.
