### PR TITLE
Adds missing dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ my %mm = (
     VERSION_FROM      => 'lib/JavaScript/V8.pm', # finds $VERSION
     PREREQ_PM         => {
       'ExtUtils::XSpp' => '0.11',
+      'ExtUtils::ParseXS' => '3.14',
       'Test::Number::Delta' => 0,
     }, # e.g., Module::Name => 1.1
     ABSTRACT_FROM  => 'lib/JavaScript/V8.pm', # retrieve abstract from module


### PR DESCRIPTION
3.14 is an educated guess for ExtUtils::ParseXS, but that version is almost 4 years old so it should be okay to require it.
