### PR TITLE
Convert JSON::PP::Boolean objects to JavaScript boolean primitives.

### DIFF
--- a/V8Context.cpp
+++ b/V8Context.cpp
@@ -630,8 +630,12 @@ V8Context::rv2v8(SV *rv, HandleMap& seen) {
     }
 
 #if PERL_VERSION > 8
-    if (SvOBJECT(sv))
+    if (SvOBJECT(sv)) {
+        const char *Perl_class = sv_reftype(sv, 1);
+        if (0 == strcmp(Perl_class, "JSON::PP::Boolean"))
+            return Boolean::New(sv_2bool(sv));
         return blessed2object(sv);
+    }
 #endif
 
     unsigned t = SvTYPE(sv);

--- a/t/boolean_PP.t
+++ b/t/boolean_PP.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl 
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+
+use JavaScript::V8;
+use JSON;
+
+my $v8context = JavaScript::V8::Context->new();
+$v8context->bind( f => JSON::false );
+ok($v8context->eval('(function() { return (f ? 1 : 0) })()') == 0, 'Testing false - should return 0');
+$v8context->bind( f => JSON::true );
+ok($v8context->eval('(function() { return (f ? 1 : 0) })()') == 1, 'Testing true - should return 1');
+ok($v8context->eval('typeof f') eq 'boolean', 'Testing the Javascript type is a boolean');
+
+done_testing;

--- a/t/boolean_XS.t
+++ b/t/boolean_XS.t
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl 
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+
+use JavaScript::V8;
+use JSON::XS;
+use Types::Serialiser;
+
+my $v8context = JavaScript::V8::Context->new();
+$v8context->bind( f => Types::Serialiser::false );
+ok($v8context->eval('(function() { return (f ? 1 : 0) })()') == 0, 'Testing false - should return 0');
+$v8context->bind( f => Types::Serialiser::true );
+ok($v8context->eval('(function() { return (f ? 1 : 0) })()') == 1, 'Testing true - should return 1');
+ok($v8context->eval('typeof f') eq 'boolean', 'Testing the Javascript type is a boolean');
+
+done_testing;


### PR DESCRIPTION
Hello David,

I'm rounding out my year doing the Perl Pull Request Challenge (PRC) - I was assigned JavaScript::V8, and looking through open issues in RT I saw #103943: 'JSON::true / JSON::false converted to empty JavaScript object'.

I've updated V8Context.cpp to convert JSON::PP::Boolean objects to a Javascript boolean primitive - hope this helps. I've added test scripts for this use case, too.

Cheers

Brad
